### PR TITLE
Update style that prevent emulator run

### DIFF
--- a/client/components/login/activate-email-sent.tsx
+++ b/client/components/login/activate-email-sent.tsx
@@ -128,7 +128,7 @@ const ActivateEmailSent = (props: any, {navigation}:any) => {
         style={Style.alignRight}
         >
             <_Button
-            style={[props.btnStyle(disabled), {marginBottom:"5px"}]}
+            style={[props.btnStyle(disabled), {marginBottom:5}]}
             onPress={() => doResendEmail()}
             disabled={disabled}
             >


### PR DESCRIPTION
Changing this style from `5px` to `5`, which is valid. `5px` was causing the android emulator expo go app to crash.