### PR TITLE
style: Improve both the input text box and messages top bar

### DIFF
--- a/client/components/messages/message-input.tsx
+++ b/client/components/messages/message-input.tsx
@@ -54,7 +54,7 @@ const MessageInput = ({chat, socket}: Props) => {
       }
       else {
         const randomNum = () => {
-          (Math.floor(Math.random() * 20) + 1).toString()
+          return (Math.floor(Math.random() * 1000000) + 1).toString();
         }
 
         const data = {
@@ -98,7 +98,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'whitesmoke',
     padding: 5,
     paddingHorizontal: 10,
-    marginTop: 10,
     alignItems: 'center',
     minHeight: 55,
   },

--- a/client/components/messages/message-input.tsx
+++ b/client/components/messages/message-input.tsx
@@ -78,6 +78,7 @@ const MessageInput = ({chat, socket}: Props) => {
         onChangeText={setNewMessage}
         onLayout={(e) => setHiddenTextWidth(e.nativeEvent.layout.width)}
         style={[styles.input, {height: height}]}
+        placeholder={'Aa'}
         multiline
       />
       <View style={styles.buttonContainer}>

--- a/client/components/messages/message-input.tsx
+++ b/client/components/messages/message-input.tsx
@@ -1,9 +1,22 @@
 import React, { useEffect, useState } from "react";
-import { TextInput, View, StyleSheet } from "react-native";
-import _Button from "../control/button";
+import { TextInput, View, StyleSheet, Pressable, Text } from "react-native";
 import { env, getLocalStorage } from "../../helper";
 import { Socket } from "socket.io-client";
 import { DefaultEventsMap } from '@socket.io/component-emitter';
+import { Svg, Path } from "react-native-svg";
+
+const sendIcon = (
+  <Svg
+    width={30}
+    height={30}
+    fill="none"
+  >
+    <Path
+      d="M25.734 14.165 5.11 3.853a.937.937 0 0 0-1.012.112.937.937 0 0 0-.31.938L6.564 15 3.75 25.069a.938.938 0 0 0 .938 1.18.938.938 0 0 0 .421-.102l20.625-10.313a.937.937 0 0 0 0-1.669ZM6.141 23.54l2.072-7.603h8.662v-1.875H8.213L6.14 6.46 23.213 15 6.14 23.54Z"
+      fill="#418DFC"
+    />
+  </Svg>
+);
 
 interface Props {
   chat: any,
@@ -13,6 +26,8 @@ interface Props {
 const MessageInput = ({chat, socket}: Props) => {
   const [newMessage, setNewMessage] = useState('');
   const [userInfo, setUserInfo] = useState<any>();
+  const [height, setHeight] = useState(0);
+  const [hiddenTextWidth, setHiddenTextWidth] = useState(0);
 
   useEffect(() => {
     getUserInfo();
@@ -61,10 +76,18 @@ const MessageInput = ({chat, socket}: Props) => {
       <TextInput
         value={newMessage}
         onChangeText={setNewMessage}
-        style={styles.input}
+        onLayout={(e) => setHiddenTextWidth(e.nativeEvent.layout.width)}
+        style={[styles.input, {height: height}]}
         multiline
       />
-      <_Button onPress={sendMessage}>Send</_Button>
+      <View style={styles.buttonContainer}>
+        <Pressable onPress={sendMessage}>
+          {sendIcon}
+        </Pressable>
+      </View>
+      <Text style={[styles.hidden, {width: hiddenTextWidth}]} onLayout={(e) => {setHeight(e.nativeEvent.layout.height)}}>
+        {newMessage}
+      </Text>
     </View>
   );
 }
@@ -77,18 +100,38 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     marginTop: 10,
     alignItems: 'center',
+    minHeight: 55,
   },
   input: {
     appearance: 'none',
     flex: 1,
     backgroundColor: 'white',
-    padding: 5,
+    padding: 10,
     marginHorizontal: 10,
 
-    borderRadius: 50,
+    borderRadius: 15,
     borderColor: 'lightgray',
     borderWidth: StyleSheet.hairlineWidth,
   },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    height: '100%',
+    paddingBottom: 9,
+    alignItems: 'flex-end'
+  },
+  hidden: {
+    position: 'absolute',
+    top: 10000,
+    right: 10000,
+    backgroundColor: 'transparent',
+    borderColor: 'transparent',
+    color: 'transparent',
+    padding: 10,
+    marginHorizontal: 10,
+    minHeight: 41,
+    maxHeight: 115,
+  }
 });
 
 export default MessageInput;

--- a/client/components/messages/message-panel.tsx
+++ b/client/components/messages/message-panel.tsx
@@ -3,15 +3,17 @@ import { View, StyleSheet, Animated, Easing, Dimensions } from 'react-native';
 import _Button from '../control/button';
 import Messages from './messages';
 import MessageInput from './message-input';
+import MessageTopBar from './message-top-bar';
 
 interface Props {
   showPanel: boolean,
   updateShowPanel: Dispatch<SetStateAction<boolean>>,
+  userInfo: any,
   chat: any,
   socket: any,
 }
 
-const MessagePanel = ({ showPanel, updateShowPanel, chat, socket }: Props) => {
+const MessagePanel = ({ showPanel, updateShowPanel, userInfo, chat, socket }: Props) => {
   // These values are mapped to percentage of screen size.
   const PANEL_OUT_OF_SCREEN = Dimensions.get('window').width * 1.5;
   const PANEL_IN_SCREEN = 0;
@@ -49,8 +51,8 @@ const MessagePanel = ({ showPanel, updateShowPanel, chat, socket }: Props) => {
           ]}
         ]}
       >
-        <_Button onPress={() => updateShowPanel(!showPanel)}>Back</_Button>
-        <Messages chat={chat} socket={socket}/>
+        <MessageTopBar chat={chat} showPanel={showPanel} updateShowPanel={updateShowPanel}/>
+        <Messages chat={chat} userInfo={userInfo} socket={socket}/>
         <MessageInput chat={chat} socket={socket}/>
       </Animated.View>
     </>

--- a/client/components/messages/message-tab.tsx
+++ b/client/components/messages/message-tab.tsx
@@ -57,11 +57,9 @@ const styles = StyleSheet.create({
   touchable: {
     flex: 1,
     flexDirection: 'row',
-    marginHorizontal: 5,
     paddingHorizontal: 10,
     paddingVertical: 5,
     height: 70,
-    borderRadius: 10,
     alignItems: 'center',
   },
   content: {

--- a/client/components/messages/message-top-bar.tsx
+++ b/client/components/messages/message-top-bar.tsx
@@ -1,0 +1,71 @@
+import { View, StyleSheet, Pressable, Text, Image } from "react-native";
+import _Button from "../control/button";
+import Svg, { Path } from "react-native-svg"
+
+
+const returnIcon = (
+  <Svg
+    width={17}
+    height={16}
+    viewBox="0 0 17 16"
+    fill="none"
+  >
+    <Path
+      d="M5.173 8L12.85.774a.433.433 0 000-.64.5.5 0 00-.68 0L4.15 7.68a.433.433 0 000 .64l8.02 7.545a.5.5 0 00.338.134.484.484 0 00.338-.134.433.433 0 000-.64L5.173 8z"
+      fill="#418DFC"
+    />
+  </Svg>
+)
+
+interface Props {
+  chat: any,
+  showPanel: any,
+  updateShowPanel: any,
+}
+
+const MessageTopBar = ({showPanel, updateShowPanel, chat}: Props) => {
+  if (!chat?.users || !chat.chatName) return <></>;
+  return (
+    <View style={styles.container}>
+      <View style={styles.buttonContainer}>
+        <Pressable onPress={() => updateShowPanel(!showPanel)}>
+          {returnIcon}
+        </Pressable>
+      </View>
+      <Image style={styles.image} source={{ uri: (chat?.users[0]?.image != null) ? chat?.users[0]?.image : 'https://reactnative.dev/img/tiny_logo.png'}} />
+      <Text numberOfLines={1} style={styles.name}>{chat.chatName}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    backgroundColor: 'white',
+    padding: 5,
+    paddingHorizontal: 10,
+    alignItems: 'center',
+    minHeight: 55,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'lightgray',
+  },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: 30,
+    height: 40,
+  },
+  image: {
+    height: 40,
+    width: 40,
+    borderRadius: 20,
+    marginRight: 10,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+  }
+});
+
+export default MessageTopBar;

--- a/client/components/messages/message.tsx
+++ b/client/components/messages/message.tsx
@@ -1,23 +1,13 @@
-import { useEffect, useState } from "react";
 import { View, StyleSheet, Text } from "react-native";
 import { Color } from "../../style";
-import { getLocalStorage } from "../../helper";
 
 interface Props {
-  message: any
+  message: any,
+  userInfo: any
 }
 
-const Message = ({ message }: Props) => {
-  const [userInfo, setUserInfo] = useState<any>();
-
-  useEffect(() => {
-    getUserInfo();
-  }, [])
-
-  const getUserInfo = async () => {
-    setUserInfo(await getLocalStorage().then((res) => {return res.user}));
-  }
-
+const Message = ({ message, userInfo }: Props) => {
+  if (!userInfo) return <></>
   const isMyMessage = () => message.userId === userInfo?.id;
 
   const styles = StyleSheet.create({
@@ -43,16 +33,20 @@ const Message = ({ message }: Props) => {
       color: Color(message.isDarkMode).black,
     }
   });
-
+  
   return (
-    <View
-      style={[
-        styles.myMessage, 
-        isMyMessage() ? null : styles.theirMessage,
-      ]}
-    >
-      <Text style={{color: isMyMessage() ? Color(message.isDarkMode).white : undefined}}>{message.content}</Text>
-    </View>
+    <>
+      {
+        isMyMessage() ?
+          <View style={styles.myMessage}>
+            <Text style={{color: Color(message.isDarkMode).white}}>{message.content}</Text>
+          </View>
+        :
+        <View style={[styles.myMessage, styles.theirMessage]}>
+          <Text>{message.content}</Text>
+        </View>
+      }
+    </>
   );
 }
 

--- a/client/components/messages/messages.tsx
+++ b/client/components/messages/messages.tsx
@@ -1,6 +1,6 @@
 import { FlatList } from "react-native";
 import Message from "./message";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { env } from "../../helper";
 import { Socket } from 'socket.io-client'
 import { DefaultEventsMap } from '@socket.io/component-emitter';
@@ -8,18 +8,24 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 interface Props {
   chat: any,
+  userInfo: any,
   socket: Socket<DefaultEventsMap, DefaultEventsMap>
 }
 
-const Messages = ({chat, socket}: Props) => {
+const Messages = ({chat, userInfo, socket}: Props) => {
   const [messages, setMessages] = useState<any[]>([]);
   const chatRef = useRef(chat);
+  const userInfoRef = useRef(userInfo);
   const messagesRef = useRef(messages);
   
   useEffect(() => {
     chatRef.current = chat
     getMessages(chat.id);
   }, [chat])
+
+  useEffect(() => {
+    userInfoRef.current = userInfo
+  }, [userInfo])
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -48,11 +54,15 @@ const Messages = ({chat, socket}: Props) => {
     });
   }
 
+  const renderItem = useCallback(({item}:any) => {return <Message message={item} userInfo={userInfoRef.current} key={item.id}/>}, []);
+
   return (
     <SafeAreaView style={{flex: 1}}>
       <FlatList
         data={messages}
-        renderItem={({ item }) => <Message message={item} key={item.id}/>}
+        renderItem={renderItem}
+        initialNumToRender={14}
+        removeClippedSubviews
         inverted
       />
     </SafeAreaView>

--- a/client/screens/messages.tsx
+++ b/client/screens/messages.tsx
@@ -15,7 +15,7 @@ const MessagesScreen = (props: any, {navigation}:any) => {
   const [currentChat, setCurrentChat] = useState({});
   const [chats, setChats] = useState<any[]>([]);
   const [userInfo, setUserInfo] = useState<any>();
-  const chatsRef = useRef(chats)
+  const chatsRef = useRef(chats);
 
   useEffect(() => {
     getUserInfo();
@@ -171,7 +171,7 @@ const MessagesScreen = (props: any, {navigation}:any) => {
           />
         }
       />
-      <MessagePanel showPanel={showPanel} socket={socket} updateShowPanel={updateShowPanel} chat={currentChat}/>
+      <MessagePanel showPanel={showPanel} socket={socket} userInfo={userInfo} updateShowPanel={updateShowPanel} chat={currentChat}/>
     </>
   );
 };


### PR DESCRIPTION
This PR add styling to the input box:
- Expandable text input (up to five lines)
- Updates send button to use svg

And it adds styling to the top bar:
- Changes back button to use svg
- Displays image of other user
- Displays name of other user

There is also minor bug fixes within this PR (mainly to improve rendering of messages).

**P.S. There is a bug with the keyboard on my emulator that is not due to my changes. Merging this PR should not result in changes to anyone else if they don't experience the same issue.**

![addLinks](https://user-images.githubusercontent.com/55557781/215900673-6622f7b5-5d03-4910-8308-a8bab3342913.gif)
