### PR TITLE
Should only get push notifications when you are not in the chat. When…

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -249,6 +249,7 @@ export const App = (props: any) => {
         }
 
         if (appState.current === 'active' && nextAppState !== 'active') {
+          setPromptShowing(false);
           let data = await getCurrentChat();
           if (data) {
             data.disabled = true;
@@ -261,6 +262,8 @@ export const App = (props: any) => {
             data.disabled = false;
             if (data.id && data.is_showing) {
               checkDismissNotifications(data.id);
+              // Update the notification count only when you are in a chat
+              getChats();
             }
             else {
               data = null;
@@ -1061,6 +1064,7 @@ export const App = (props: any) => {
                   setUpdatePicture={setUpdatePicture}
                   setForceUpdateAccount={setForceUpdateAccount}
                   setPromptShowing={setPromptShowing}
+                  promptShowing={promptShowing}
                   />}
                   </Stack.Screen>
                   <Stack.Screen
@@ -1140,6 +1144,7 @@ export const App = (props: any) => {
                   setNavSelector={setNavSelector}
                   updatePicture={updatePicture}
                   setPromptShowing={setPromptShowing}
+                  promptShowing={promptShowing}
                   />}
                   </Stack.Screen>
                   <Stack.Screen

--- a/client/components/account/account-about-you.tsx
+++ b/client/components/account/account-about-you.tsx
@@ -44,7 +44,6 @@ const AccountAbout = (props: any) => {
         "🏛 History",
         "🌸 Anime",
         "🛍 Shopping",
-        "🍻 Alcohol",
       ];
 
     useEffect(() => {

--- a/client/components/account/account-basic-info.tsx
+++ b/client/components/account/account-basic-info.tsx
@@ -45,7 +45,14 @@ const AccountInfo = (props: any) => {
     const zipRef = React.useRef<React.ElementRef<typeof TextInput> | null>(null);
     const cityRef = React.useRef<React.ElementRef<typeof TextInput> | null>(null);
     const stateRef = React.useRef<React.ElementRef<typeof TextInput> | null>(null);
-    const [refreshing, setRefreshing] = useState(false);  
+    const [refreshing, setRefreshing] = useState(false); 
+    const monthsArray = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+    
+    useEffect(() => {
+        if (!props.promptShowing)
+        closePasswordPrompt();
+    }, [props.promptShowing]);
+    
     useEffect(() => {
         if (!init) {
             onLoad();
@@ -168,7 +175,7 @@ const AccountInfo = (props: any) => {
 
     const getYearOptions = () => {
         var years = [];
-        var year = new Date().getFullYear() - 15; // Age bumper, no kids
+        var year = new Date().getFullYear() - 18; // Age bumper, no kids
         for (var i = 0; i < 100; i++) {
             years.push({key:year, value:year.toString()});
             year--;
@@ -177,7 +184,17 @@ const AccountInfo = (props: any) => {
     }
 
     const getMonthOptions = () => {
-        return [{key:1, value:'January'},{key:2, value:'February'},{key:3, value:'March'},{key:4, value:'April'},{key:5, value:'May'},{key:6, value:'June'},{key:7, value:'July'},{key:8, value:'August'},{key:9, value:'September'},{key:10, value:'October'},{key:11, value:'November'},{key:12, value:'December'}]
+        var months = [];
+        if (year === (new Date().getFullYear() - 18).toString())
+            var m = new Date().getMonth() + 1;
+        else
+            var m = 12;
+
+        for (var i = 0; i < m; i++) {
+            months.push({key: i + 1, value: monthsArray[i]});
+        }
+
+        return months;
     }
 
     const getStateOptions = () => {
@@ -186,7 +203,7 @@ const AccountInfo = (props: any) => {
     }
 
     const setGenderOptions = () => {
-        return [{key:'Male', value: 'Male'}, {key:'Female', value: 'Female'}, {key:'Other', value: 'Other'}];
+        return [{key:'Male', value: 'Male'}, {key:'Female', value: 'Female'}, {key:'Non-Binary', value: 'Non-Binary'}];
     }
 
     const getDayOptions = () => {
@@ -194,13 +211,16 @@ const AccountInfo = (props: any) => {
         if (year && month) {
             let m = getMonthOptions().find(x => x.value == month);
             if (m) {
+                let today = new Date();
                 var count = new Date(parseInt(year), parseInt(m.key.toString()), 0).getDate();
                 for (var i = 1; i <= count; i++) {
+                    if (year === (today.getFullYear() - 18).toString() && today.getMonth() + 1 === m.key && i < today.getDate()) {
+                        continue;
+                    }
                     days.push({key:i, value:i.toString()});
                 }
                 if (day && parseInt(day) > count) {
                     setDay('');
-
                 }
             }
         }

--- a/client/components/control/dropdown.tsx
+++ b/client/components/control/dropdown.tsx
@@ -42,19 +42,21 @@ const _Dropdown = (props: any, {navigation}:any) => {
             let l_options = options;
             if (l_options.length == 0)
                 l_options = mappedItems(props.value);
-            l_options.forEach(x => {
-                if (x && x['props']) {
-                    let prop = x['props'];
-                    if (prop['item']) {
-                        let item = prop['item'];
-                        if (props.value === item['value']) {
-                            setDataInit(true);
-                            select(item);
-                            return;
+            if (l_options && l_options.length > 0) {
+                l_options.forEach(x => {
+                    if (x && x['props']) {
+                        let prop = x['props'];
+                        if (prop['item']) {
+                            let item = prop['item'];
+                            if (props.value === item['value']) {
+                                setDataInit(true);
+                                select(item);
+                                return;
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
         }
         if (!init) {
             mappedItems(props.value);

--- a/client/components/listings/create-listing.tsx
+++ b/client/components/listings/create-listing.tsx
@@ -25,6 +25,13 @@ const CreateListing = (props: any) => {
   const [prompt, setPrompt] = useState(false);
 
   const [deleteImageURLs, setDeleteImageURLs] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!props.promptShowing) {
+      cancelPrompt();
+      props.setIsLocationNotFound(false);
+    }
+  }, [props.promptShowing]);
   
   useEffect(() => {
     getUserInfo();
@@ -358,7 +365,6 @@ const CreateListing = (props: any) => {
   };
 
   const handleSubmitListing = async () => {
-
     const validAddress = await checkAddressValidity(formData.address + ", " + formData.city + ", FL " + formData.zipcode);
     
     if (validAddress) {

--- a/client/components/listings/listing.tsx
+++ b/client/components/listings/listing.tsx
@@ -49,7 +49,11 @@ const ListingView = (props: any) => {
     }
   };
   
-  
+  useEffect(() => {
+    if (!props.promptShowing) {
+      setShowDeleteConfirmation(false);
+    }
+  }, [props.promptShowing]);
 
   const refresh = () => {
     setRefreshing(true);
@@ -266,7 +270,7 @@ const ListingView = (props: any) => {
 
   const dialogStyle = () => {
     let style = [];
-    style.push({backgroundColor: !props.isDarkMode ? Color(props.isDarkMode).holderMask : Color(props.isDarkMode).promptMaskMobile});
+    style.push({backgroundColor: Color(props.isDarkMode).promptMaskMobile});
     return style;
   }
 

--- a/client/screens/account.tsx
+++ b/client/screens/account.tsx
@@ -117,6 +117,7 @@ const AccountScreen = (props: any) => {
         setUpdatePicture={props.setUpdatePicture}
         setForceUpdateAccount={props.setForceUpdateAccount}
         setPromptShowing={props.setPromptShowing}
+        promptShowing={props.promptShowing}
         />
         :
         <View>

--- a/client/screens/filters.tsx
+++ b/client/screens/filters.tsx
@@ -38,7 +38,7 @@ const FiltersScreen = (props: any) => {
         "🛍 Shopping"
     ];
 
-    const genderOptions = ["Male", "Female", "Other"];
+    const genderOptions = ["Male", "Female", "Non-Binary"];
     const locationOptions = ["On Campus", "Oviedo", "Union Park", "Orlando", "Lake Nona"];
     const sharingPrefOptions = ["Never", "Sometimes", "Always"];
 

--- a/client/screens/listings.tsx
+++ b/client/screens/listings.tsx
@@ -381,6 +381,7 @@ return (
             dirty={dirty}
             setDirty={setDirty}
             setPromptShowing={props.setPromptShowing}
+            promptShowing={props.promptShowing}
             isLocationNotFound={isLocationNotFound}
             setIsLocationNotFound={setIsLocationNotFound}
           />
@@ -403,6 +404,7 @@ return (
         setRefreshListing={setRefreshListing}
         mobile={props.mobile}
         setPromptShowing={props.setPromptShowing}
+        promptShowing={props.promptShowing}
       />
     )}
   </View>

--- a/client/screens/messages.tsx
+++ b/client/screens/messages.tsx
@@ -225,7 +225,6 @@ const MessagesScreen = (props: any) => {
       const newMsg = chats.find(chat => chat.id === props.receiveMessage?.chatId);
       if (newMsg && newMsg.blocked)
         return;
-
       setReceiveMsg(props.receiveMessage);
       updateTabs(props.receiveMessage);
       props.setReceiveMessage(null);
@@ -253,6 +252,8 @@ const MessagesScreen = (props: any) => {
     if (chats && props.openChatFromPush) {
       let chat = chats.find(chat => chat.id === props.openChatFromPush);
       if (chat) {
+        let data = {id: props.openChatFromPush, is_showing: showPanel, disabled: false, current_page: NavTo.Messages};
+        setLocalAppSettingsCurrentChat(data);
         setCurrentChat(chat);
         updateShowPanel(true);
         props.setOpenChatFromPush('');


### PR DESCRIPTION
… you entered a chat from push notification it wasn't blocking notifications for that chat before.

Make sure that age gating is set to 18 and that you can't select any day or month younger than 18 and that other ages work and the day/month isn't broken for them Check if everywhere says Non-Binary. Explore, explore filters, profile, my profile Users shouldn't be able to select alcohol as an interest anymore. It might still show up on profiles but it shouldn't be in filters or account about section for tag selection All prompts will now close if you leave the app. This is to prevent the masking from getting stuck. Check all places: Delete Listing, Update Password, Location Not Found, Abandon Create Listing Ensure that when you are in a chat and then put app in background that when you send a message from another account, open the app back up and go out of the chat that the notification count updates properly